### PR TITLE
Implementación de roles de usuario

### DIFF
--- a/api/middleware/requireAuth.js
+++ b/api/middleware/requireAuth.js
@@ -1,13 +1,39 @@
 import http from 'http2';
 
-const requireAuth = (req, res, next) => {
-  if (!req.auth) {
+/**
+ * Middleware que valida si el usuario tiene un token de acceso y si tiene los permisos necesarios (rol) para acceder a
+ * un recurso. Un usuario con rol de administrador (`admin`) tiene acceso a todos los recursos del API.
+ * @param {[string]} authorizedRoles - Arreglo de roles permitidos para acceder al recurso. Si el arreglo está vacío,
+ * se permite el acceso a cualquier usuario con token de acceso.
+ * @returns {function} Middleware de Express que valida si el usuario tiene un token de acceso y si tiene los permisos
+ * necesarios (rol) para acceder a un recurso.
+ */
+const requireAuth = (authorizedRoles = []) => {
+  return (req, res, next) => {
+    if (!req.auth) {
+      return res
+        .status(http.constants.HTTP_STATUS_UNAUTHORIZED)
+        .json({ message: "No se encontró el token de acceso" });
+    }
+
+    if (authorizedRoles.length <= 0) {
+      return next();
+    }
+
+    const userRoles = req.auth.realm_access.roles;
+
+    if (userRoles.includes('admin')) {
+      return next();
+    }
+
+    if (userRoles.some(userRole => authorizedRoles.includes(userRole))) {
+      return next();
+    }
+
     return res
       .status(http.constants.HTTP_STATUS_UNAUTHORIZED)
-      .json({ message: "No se encontró el token de acceso" });
-  }
-
-  next();
-}
+      .json({ message: "No tienes permisos para acceder a este recurso" });
+  };
+};
 
 export default requireAuth;

--- a/api/server.js
+++ b/api/server.js
@@ -14,7 +14,7 @@ app.use(validateJwt);
 
 // rutas
 app.get('/api', (req, res) => res.status(http.constants.HTTP_STATUS_OK).json({ message: 'Hola, Mundo!' }));
-app.use('/api/test/auth', requireAuth, authTestRouts);
+app.use('/api/test/auth', requireAuth(), authTestRouts);
 
 // iniciar el servidor
 app.listen(config.API_PORT, () => console.log(`Servidor escuchando en el puerto ${config.API_PORT}`));

--- a/api/test/controllers/authTest.controller.js
+++ b/api/test/controllers/authTest.controller.js
@@ -5,4 +5,24 @@ const protect = (req, res) => {
   return res.status(http.constants.HTTP_STATUS_OK).json({ message: 'Ruta protegida' });
 };
 
-export default { protect };
+const customer = (req, res) => {
+  console.log('Ruta de cliente');
+  return res.status(http.constants.HTTP_STATUS_OK).json({ message: 'Ruta de cliente' });
+}
+
+const camera = (req, res) => {
+  console.log('Ruta de cámara');
+  return res.status(http.constants.HTTP_STATUS_OK).json({ message: 'Ruta de cámara' });
+}
+
+const operator = (req, res) => {
+  console.log('Ruta de operador');
+  return res.status(http.constants.HTTP_STATUS_OK).json({ message: 'Ruta de operador' });
+}
+
+const admin = (req, res) => {
+  console.log('Ruta de administrador');
+  return res.status(http.constants.HTTP_STATUS_OK).json({ message: 'Ruta de administrador' });
+}
+
+export default { protect, customer, camera, operator, admin };

--- a/api/test/routes/authTest.routes.js
+++ b/api/test/routes/authTest.routes.js
@@ -1,9 +1,14 @@
 import express from 'express';
 
 import authTestController from '../controllers/authTest.controller.js';
+import requireAuth from '../../middleware/requireAuth.js';
 
 const router = express.Router();
 
 router.get('/protect', authTestController.protect);
+router.get('/customer', requireAuth(['customer']), authTestController.customer);
+router.get('/camera', requireAuth(['camera']), authTestController.camera);
+router.get('/operator', requireAuth(['operator']), authTestController.operator);
+router.get('/admin', requireAuth(['admin']), authTestController.admin);
 
 export default router;

--- a/keycloak/default-realm.json
+++ b/keycloak/default-realm.json
@@ -47,6 +47,22 @@
   "failureFactor" : 30,
   "roles" : {
     "realm" : [ {
+      "id" : "6475b0b9-3bb8-4e59-a149-0d129820ae77",
+      "name" : "admin",
+      "description" : "Rol de administrador para SADAAE",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "f380d00d-195c-43d2-b462-886c0a9577c0",
+      "attributes" : { }
+    }, {
+      "id" : "75f90dfa-2eea-47c9-b2ca-3606d10523df",
+      "name" : "operator",
+      "description" : "Rol de operador para SADAAE",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "f380d00d-195c-43d2-b462-886c0a9577c0",
+      "attributes" : { }
+    }, {
       "id" : "e66f1809-8226-4ed7-be17-beebe61ae8a9",
       "name" : "uma_authorization",
       "description" : "${role_uma_authorization}",
@@ -69,9 +85,25 @@
       "containerId" : "f380d00d-195c-43d2-b462-886c0a9577c0",
       "attributes" : { }
     }, {
+      "id" : "799472b2-8937-4740-8cec-2acc381adf10",
+      "name" : "camera",
+      "description" : "Rol de cámara para SADAAE",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "f380d00d-195c-43d2-b462-886c0a9577c0",
+      "attributes" : { }
+    }, {
       "id" : "0a14412c-8ca1-4977-aac0-58799dccf269",
       "name" : "offline_access",
       "description" : "${role_offline-access}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "f380d00d-195c-43d2-b462-886c0a9577c0",
+      "attributes" : { }
+    }, {
+      "id" : "3d49571c-60ac-4ae3-97e4-2d64b3153739",
+      "name" : "customer",
+      "description" : "Rol de cliente para SADAAE",
       "composite" : false,
       "clientRole" : false,
       "containerId" : "f380d00d-195c-43d2-b462-886c0a9577c0",
@@ -85,7 +117,7 @@
         "composite" : true,
         "composites" : {
           "client" : {
-            "realm-management" : [ "view-users", "manage-events", "view-events", "create-client", "view-identity-providers", "view-clients", "manage-realm", "query-realms", "query-users", "impersonation", "manage-authorization", "manage-clients", "manage-identity-providers", "query-clients", "manage-users", "view-realm", "query-groups", "view-authorization" ]
+            "realm-management" : [ "view-users", "manage-events", "view-events", "create-client", "view-identity-providers", "manage-realm", "query-realms", "view-clients", "query-users", "manage-authorization", "impersonation", "manage-clients", "manage-identity-providers", "query-clients", "manage-users", "view-realm", "query-groups", "view-authorization" ]
           }
         },
         "clientRole" : true,
@@ -397,7 +429,7 @@
     } ],
     "disableableCredentialTypes" : [ ],
     "requiredActions" : [ ],
-    "realmRoles" : [ "default-roles-sadaae" ],
+    "realmRoles" : [ "admin", "default-roles-sadaae" ],
     "notBefore" : 0,
     "groups" : [ ]
   }, {
@@ -420,7 +452,21 @@
     } ],
     "disableableCredentialTypes" : [ ],
     "requiredActions" : [ ],
-    "realmRoles" : [ "default-roles-sadaae" ],
+    "realmRoles" : [ "operator", "default-roles-sadaae" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
+    "id" : "5b3ed074-faa6-4f9e-97a1-2d2b1069ef62",
+    "username" : "service-account-sadaae-api",
+    "emailVerified" : false,
+    "createdTimestamp" : 1741889136783,
+    "enabled" : true,
+    "totp" : false,
+    "serviceAccountClientId" : "sadaae-api",
+    "credentials" : [ ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-sadaae", "camera" ],
     "notBefore" : 0,
     "groups" : [ ]
   }, {
@@ -443,7 +489,7 @@
     } ],
     "disableableCredentialTypes" : [ ],
     "requiredActions" : [ ],
-    "realmRoles" : [ "default-roles-sadaae" ],
+    "realmRoles" : [ "default-roles-sadaae", "customer" ],
     "notBefore" : 0,
     "groups" : [ ]
   } ],
@@ -637,7 +683,7 @@
     "standardFlowEnabled" : true,
     "implicitFlowEnabled" : false,
     "directAccessGrantsEnabled" : true,
-    "serviceAccountsEnabled" : false,
+    "serviceAccountsEnabled" : true,
     "publicClient" : false,
     "frontchannelLogout" : true,
     "protocol" : "openid-connect",
@@ -687,9 +733,10 @@
       "config" : {
         "id.token.claim" : "false",
         "lightweight.claim" : "false",
-        "access.token.claim" : "true",
         "introspection.token.claim" : "true",
-        "included.custom.audience" : "http://localhost:3000/api"
+        "access.token.claim" : "true",
+        "included.custom.audience" : "http://localhost:3000/api",
+        "userinfo.token.claim" : "false"
       }
     }, {
       "id" : "a1c45457-a365-4d2b-8f05-2a4c0dcc3387",
@@ -706,7 +753,7 @@
         "multivalued" : "true"
       }
     } ],
-    "defaultClientScopes" : [ "web-origins", "acr", "profile", "basic", "email" ],
+    "defaultClientScopes" : [ "service_account", "web-origins", "acr", "profile", "basic", "email" ],
     "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
   }, {
     "id" : "08200060-c6ea-4e51-9ff5-94de78c3f8ae",
@@ -1168,28 +1215,6 @@
       "config" : { }
     } ]
   }, {
-    "id" : "75a084f2-6af5-4392-9eed-3e19bed91773",
-    "name" : "acr",
-    "description" : "OpenID Connect scope for add acr (authentication context class reference) to the token",
-    "protocol" : "openid-connect",
-    "attributes" : {
-      "include.in.token.scope" : "false",
-      "display.on.consent.screen" : "false"
-    },
-    "protocolMappers" : [ {
-      "id" : "6a8a2d0a-4c78-40ee-90f5-2fee61484d32",
-      "name" : "acr loa level",
-      "protocol" : "openid-connect",
-      "protocolMapper" : "oidc-acr-mapper",
-      "consentRequired" : false,
-      "config" : {
-        "id.token.claim" : "true",
-        "introspection.token.claim" : "true",
-        "access.token.claim" : "true",
-        "userinfo.token.claim" : "true"
-      }
-    } ]
-  }, {
     "id" : "9a150425-1d8b-442d-a6d2-cac19fd3e112",
     "name" : "organization",
     "description" : "Additional claims about the organization a subject belongs to",
@@ -1213,6 +1238,28 @@
         "access.token.claim" : "true",
         "claim.name" : "organization",
         "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "75a084f2-6af5-4392-9eed-3e19bed91773",
+    "name" : "acr",
+    "description" : "OpenID Connect scope for add acr (authentication context class reference) to the token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "6a8a2d0a-4c78-40ee-90f5-2fee61484d32",
+      "name" : "acr loa level",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-acr-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "introspection.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
       }
     } ]
   }, {
@@ -1436,7 +1483,7 @@
       "subType" : "anonymous",
       "subComponents" : { },
       "config" : {
-        "allowed-protocol-mapper-types" : [ "oidc-address-mapper", "oidc-full-name-mapper", "oidc-usermodel-attribute-mapper", "oidc-usermodel-property-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-role-list-mapper", "saml-user-attribute-mapper", "saml-user-property-mapper" ]
+        "allowed-protocol-mapper-types" : [ "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper", "oidc-address-mapper", "saml-user-property-mapper", "oidc-usermodel-attribute-mapper", "saml-role-list-mapper", "saml-user-attribute-mapper", "oidc-usermodel-property-mapper" ]
       }
     }, {
       "id" : "a9b8995d-c7c7-46fa-ad0e-b52b7d8dc855",
@@ -1445,7 +1492,7 @@
       "subType" : "authenticated",
       "subComponents" : { },
       "config" : {
-        "allowed-protocol-mapper-types" : [ "oidc-usermodel-property-mapper", "saml-role-list-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper", "oidc-usermodel-attribute-mapper", "saml-user-attribute-mapper", "oidc-address-mapper", "saml-user-property-mapper" ]
+        "allowed-protocol-mapper-types" : [ "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper", "oidc-usermodel-property-mapper", "saml-role-list-mapper", "saml-user-attribute-mapper", "oidc-address-mapper", "oidc-usermodel-attribute-mapper", "saml-user-property-mapper" ]
       }
     }, {
       "id" : "c0187572-93a6-4723-bde9-6fa5e2f36f78",


### PR DESCRIPTION
Este PR introduce cambios significativos al middleware de autorización, rutas, y configuración de roles en el realm por defecto de Keycloak (`sadaae`). Los cambios más importantes incluyen la modificación del middleware `requireAuth` para aceptar una lista de roles autorizados, actualizar las rutas de para probar el middleware mejorado, y agregar nuevos roles a la configuración del realm por defecto de Keycloak.

### Mejoras al middleware de autorización

* [`api/middleware/requireAuth.js`](diffhunk://#diff-c34c969614f13c3b9e9db19ab8e6554468f53f7af878bc3b0f7bcedb0e0e16efL3-R38): Refactorizar `requireAuth` para aceptar un arreglo de roles autorizados y validar los permisos de un usuario basado en esos roles.

### Actualizaciones a las rutas de prueba

* [`api/server.js`](diffhunk://#diff-9a833c35e47340f0693af8115da337dff6f2a7576b805dc884d3437b8fec1228L17-R17): Se actualizó la ruta `/api/test/auth` para usar el middleware `requireAuth` mejorado sin algún rol en específico.
* [`api/test/routes/authTest.routes.js`](diffhunk://#diff-85005243d7a072206fa31099a1ddd0a72fe990f82e25539f07fb2f0709a22106R4-R12): Agregar nuevas rutas con acceso basado en roles específicos usando el middleware mejorado `requireAuth`.

### Cambios a la configuración de Keycloak

* [`keycloak/default-realm.json`](diffhunk://#diff-57ea732c3b142e2f76ec83d5b8fbad60e9acb9de9270e7718b491c903eaa5224R50-R65): Se agregaron nuevos roles al realm por defecto de Keycloak (`admin`, `operator`, `camera`, `customer`), y se asignaron a las cuentas registradas por defecto. También se activaron los roles de cuentas de servicio en el cliente `sadaae-api` para las cámaras de seguridad.

#### Roles agregadas

- `admin`: administrador del sistema
- `operator`: operador y/o despachador de seguridad pública
- `camera`: rol de servicio para las cámaras de seguridad
- `customer`: rol de usuario final
