### PR TITLE
Implementación de autorización UMA

### DIFF
--- a/api/config/config.js
+++ b/api/config/config.js
@@ -4,6 +4,7 @@ const config = {
   OIDC_AUDIENCE: process.env.OIDC_AUDIENCE || 'http://localhost:3000/api',
   OIDC_ISSUER: process.env.OIDC_ISSUER || 'http://localhost:8080/realms/sadaae',
   OIDC_JWKS_URI: process.env.OIDC_JWKS_URI || 'http://localhost:8080/realms/sadaae/protocol/openid-connect/certs',
+  OIDC_TOKEN_URI: process.env.OIDC_TOKEN_URI || 'http://localhost:8080/realms/sadaae/protocol/openid-connect/token',
 };
 
 export default config;

--- a/api/default.env
+++ b/api/default.env
@@ -3,3 +3,4 @@ API_PORT=3000
 OIDC_AUDIENCE=http://localhost:3000/api
 OIDC_ISSUER=http://localhost:8080/realms/sadaae
 OIDC_JWKS_URI=http://sadaae-keycloak:8080/realms/sadaae/protocol/openid-connect/certs
+OIDC_TOKEN_URI=http://sadaae-keycloak:8080/realms/sadaae/protocol/openid-connect/token

--- a/api/middleware/requireAuth.js
+++ b/api/middleware/requireAuth.js
@@ -1,39 +1,72 @@
+import axios from 'axios';
 import http from 'http2';
 
+import config from '../config/config.js';
+
 /**
- * Middleware que valida si el usuario tiene un token de acceso y si tiene los permisos necesarios (rol) para acceder a
- * un recurso. Un usuario con rol de administrador (`admin`) tiene acceso a todos los recursos del API.
- * @param {[string]} authorizedRoles - Arreglo de roles permitidos para acceder al recurso. Si el arreglo está vacío,
- * se permite el acceso a cualquier usuario con token de acceso.
+ * Middleware que valida si el usuario tiene un token de acceso y si tiene los permisos necesarios para acceder a un
+ * recurso.
+ * @param {string} scope - Alcance que se requiere para acceder al recurso (e.j. `'create'` `'read'`, `'update'`,
+ * `'delete'`). Si no se especifica, implica que el recurso no requiere de un alcance en específico.
  * @returns {function} Middleware de Express que valida si el usuario tiene un token de acceso y si tiene los permisos
- * necesarios (rol) para acceder a un recurso.
+ * necesarios para acceder a un recurso.
+ * 
+ * @example
+ * import express from 'express';
+ * import requireAuth from '../middleware/requireAuth.js';
+ * 
+ * const router = express.Router();
+ * 
+ * router.get('/user/:id', requireAuth('read'), (req, res) => {
+ *   res.status(200).json({ message: 'Usuario encontrado' });
+ * }
+ * 
+ * router.get('/protected', requireAuth(), (req, res) => {
+ *   res.status(200).json({ message: 'Recurso protegido' });
+ * })
  */
-const requireAuth = (authorizedRoles = []) => {
-  return (req, res, next) => {
+const requireAuth = (scope = "") => {
+  return async (req, res, next) => {
     if (!req.auth) {
       return res
         .status(http.constants.HTTP_STATUS_UNAUTHORIZED)
         .json({ message: "No se encontró el token de acceso" });
     }
 
-    if (authorizedRoles.length <= 0) {
-      return next();
+    const formData = new FormData();
+    const permissionUri = req.originalUrl.replace('/api', '');
+
+    formData.append('grant_type', 'urn:ietf:params:oauth:grant-type:uma-ticket');
+    formData.append('response_mode', 'decision');
+    formData.append('audience', 'sadaae-api');
+    formData.append('permission', `${permissionUri}#${scope}`);
+    formData.append('permission_resource_format', 'uri');
+    formData.append('permission_resource_matching_uri', 'true');
+
+    try {
+      const authResponse = await axios({
+        method: 'post',
+        url: config.OIDC_TOKEN_URI,
+        data: formData,
+        headers: {
+          'Content-Type': 'multipart/form-data',
+          'Authorization': req.headers.authorization,
+        },
+        validateStatus: (status) => (status >= 200 && status < 500),
+      });
+
+      if (authResponse.data.result === true) {
+        return next();
+      }
+
+      return res.status(authResponse.status).json(authResponse.data);
     }
+    catch (error) {
+      console.log(error);
 
-    const userRoles = req.auth.realm_access.roles;
-
-    if (userRoles.includes('admin')) {
-      return next();
+      return res.status(http.constants.HTTP_STATUS_INTERNAL_SERVER_ERROR).json({ message: error });
     }
-
-    if (userRoles.some(userRole => authorizedRoles.includes(userRole))) {
-      return next();
-    }
-
-    return res
-      .status(http.constants.HTTP_STATUS_UNAUTHORIZED)
-      .json({ message: "No tienes permisos para acceder a este recurso" });
-  };
+  }
 };
 
 export default requireAuth;

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
+        "axios": "^1.8.3",
         "express": "^4.21.2",
         "express-jwt": "^8.5.1",
         "jwks-rsa": "^3.1.0",
@@ -188,6 +189,23 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
+      "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -349,6 +367,18 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -407,6 +437,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -491,6 +530,21 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -638,6 +692,41 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -757,6 +846,21 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -1330,6 +1434,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/api/package.json
+++ b/api/package.json
@@ -16,6 +16,7 @@
     "start": "node server.js"
   },
   "dependencies": {
+    "axios": "^1.8.3",
     "express": "^4.21.2",
     "express-jwt": "^8.5.1",
     "jwks-rsa": "^3.1.0",

--- a/api/test/routes/authTest.routes.js
+++ b/api/test/routes/authTest.routes.js
@@ -1,14 +1,13 @@
 import express from 'express';
 
 import authTestController from '../controllers/authTest.controller.js';
-import requireAuth from '../../middleware/requireAuth.js';
 
 const router = express.Router();
 
 router.get('/protect', authTestController.protect);
-router.get('/customer', requireAuth(['customer']), authTestController.customer);
-router.get('/camera', requireAuth(['camera']), authTestController.camera);
-router.get('/operator', requireAuth(['operator']), authTestController.operator);
-router.get('/admin', requireAuth(['admin']), authTestController.admin);
+router.get('/customer', authTestController.customer);
+router.get('/camera', authTestController.camera);
+router.get('/operator', authTestController.operator);
+router.get('/admin', authTestController.admin);
 
 export default router;

--- a/keycloak/default-realm.json
+++ b/keycloak/default-realm.json
@@ -117,7 +117,7 @@
         "composite" : true,
         "composites" : {
           "client" : {
-            "realm-management" : [ "view-users", "manage-events", "view-events", "create-client", "view-identity-providers", "manage-realm", "query-realms", "view-clients", "query-users", "manage-authorization", "impersonation", "manage-clients", "manage-identity-providers", "query-clients", "manage-users", "view-realm", "query-groups", "view-authorization" ]
+            "realm-management" : [ "view-users", "manage-events", "view-events", "create-client", "view-identity-providers", "manage-realm", "query-realms", "view-clients", "query-users", "impersonation", "manage-authorization", "manage-clients", "manage-identity-providers", "query-clients", "manage-users", "view-realm", "query-groups", "view-authorization" ]
           }
         },
         "clientRole" : true,
@@ -278,7 +278,14 @@
         "containerId" : "a0c67139-96d8-4b90-9c5b-8de2a96285d6",
         "attributes" : { }
       } ],
-      "sadaae-api" : [ ],
+      "sadaae-api" : [ {
+        "id" : "3c6e2395-e07c-4bdf-8bff-b025489f830d",
+        "name" : "uma_protection",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "92443320-e639-457f-9d36-04d29b10263a",
+        "attributes" : { }
+      } ],
       "security-admin-console" : [ ],
       "admin-cli" : [ ],
       "account-console" : [ ],
@@ -467,6 +474,9 @@
     "disableableCredentialTypes" : [ ],
     "requiredActions" : [ ],
     "realmRoles" : [ "default-roles-sadaae", "camera" ],
+    "clientRoles" : {
+      "sadaae-api" : [ "uma_protection" ]
+    },
     "notBefore" : 0,
     "groups" : [ ]
   }, {
@@ -667,7 +677,7 @@
     "clientId" : "sadaae-api",
     "name" : "SADAAE API",
     "description" : "RESTful API de Node.js para SADAAE",
-    "rootUrl" : "",
+    "rootUrl" : "http://localhost:3000/api",
     "adminUrl" : "",
     "baseUrl" : "",
     "surrogateAuthRequired" : false,
@@ -684,6 +694,7 @@
     "implicitFlowEnabled" : false,
     "directAccessGrantsEnabled" : true,
     "serviceAccountsEnabled" : true,
+    "authorizationServicesEnabled" : true,
     "publicClient" : false,
     "frontchannelLogout" : true,
     "protocol" : "openid-connect",
@@ -754,7 +765,155 @@
       }
     } ],
     "defaultClientScopes" : [ "service_account", "web-origins", "acr", "profile", "basic", "email" ],
-    "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+    "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ],
+    "authorizationSettings" : {
+      "allowRemoteResourceManagement" : true,
+      "policyEnforcementMode" : "ENFORCING",
+      "resources" : [ {
+        "name" : "admin-auth-test",
+        "type" : "admin:test",
+        "ownerManagedAccess" : false,
+        "displayName" : "Administrator Authorization Test",
+        "attributes" : { },
+        "uris" : [ "/test/auth/admin" ],
+        "icon_uri" : ""
+      }, {
+        "name" : "operator-auth-test",
+        "type" : "operator:test",
+        "ownerManagedAccess" : false,
+        "displayName" : "Operator Authorization Test",
+        "attributes" : { },
+        "uris" : [ "/test/auth/operator" ],
+        "icon_uri" : ""
+      }, {
+        "name" : "camera-auth-test",
+        "type" : "camera:test",
+        "ownerManagedAccess" : false,
+        "displayName" : "Camera Authorization Test",
+        "attributes" : { },
+        "uris" : [ "/test/auth/camera" ],
+        "icon_uri" : ""
+      }, {
+        "name" : "customer-auth-test",
+        "type" : "customer:test",
+        "ownerManagedAccess" : false,
+        "displayName" : "Customer Authorization Test",
+        "attributes" : { },
+        "uris" : [ "/test/auth/customer" ],
+        "icon_uri" : ""
+      }, {
+        "name" : "auth-test",
+        "type" : "test",
+        "ownerManagedAccess" : false,
+        "displayName" : "Authorization Test",
+        "attributes" : { },
+        "uris" : [ "/test/auth/protect" ],
+        "icon_uri" : ""
+      } ],
+      "policies" : [ {
+        "name" : "Default Policy",
+        "description" : "A policy that grants access only for users within this realm",
+        "type" : "js",
+        "logic" : "POSITIVE",
+        "decisionStrategy" : "AFFIRMATIVE",
+        "config" : {
+          "code" : "// by default, grants any permission associated with this policy\n$evaluation.grant();\n"
+        }
+      }, {
+        "name" : "Admins Test Policy",
+        "description" : "Política de prueba que define que solo los usuarios con rol de Administrador pueden acceder",
+        "type" : "role",
+        "logic" : "POSITIVE",
+        "decisionStrategy" : "UNANIMOUS",
+        "config" : {
+          "fetchRoles" : "false",
+          "roles" : "[{\"id\":\"admin\",\"required\":true}]"
+        }
+      }, {
+        "name" : "Cameras or Admins Test Policy",
+        "description" : "Política de prueba que define que solo los usuarios con rol de Cámara o Administrador pueden acceder",
+        "type" : "role",
+        "logic" : "POSITIVE",
+        "decisionStrategy" : "UNANIMOUS",
+        "config" : {
+          "fetchRoles" : "false",
+          "roles" : "[{\"id\":\"admin\",\"required\":false},{\"id\":\"camera\",\"required\":false}]"
+        }
+      }, {
+        "name" : "Customer or Admins Test Policy",
+        "description" : "Política de prueba que define que solo los usuarios con rol de Cliente o Administrador pueden acceder",
+        "type" : "role",
+        "logic" : "POSITIVE",
+        "decisionStrategy" : "UNANIMOUS",
+        "config" : {
+          "fetchRoles" : "false",
+          "roles" : "[{\"id\":\"customer\",\"required\":false},{\"id\":\"admin\",\"required\":false}]"
+        }
+      }, {
+        "name" : "Operators or Admin Test Policy",
+        "description" : "Política de prueba que define que solo los usuarios con rol de Operador o Administrador pueden acceder",
+        "type" : "role",
+        "logic" : "POSITIVE",
+        "decisionStrategy" : "UNANIMOUS",
+        "config" : {
+          "fetchRoles" : "false",
+          "roles" : "[{\"id\":\"admin\",\"required\":false},{\"id\":\"operator\",\"required\":false}]"
+        }
+      }, {
+        "name" : "Customer Test Permission",
+        "description" : "Permiso de prueba que aplica a usuarios con rol de Cliente",
+        "type" : "resource",
+        "logic" : "POSITIVE",
+        "decisionStrategy" : "UNANIMOUS",
+        "config" : {
+          "resources" : "[\"customer-auth-test\"]",
+          "applyPolicies" : "[\"Customer or Admins Test Policy\"]"
+        }
+      }, {
+        "name" : "Camera Test Permission",
+        "description" : "Permiso de prueba que aplica a usuarios con rol de Cámara",
+        "type" : "resource",
+        "logic" : "POSITIVE",
+        "decisionStrategy" : "UNANIMOUS",
+        "config" : {
+          "resources" : "[\"camera-auth-test\"]",
+          "applyPolicies" : "[\"Cameras or Admins Test Policy\"]"
+        }
+      }, {
+        "name" : "Admin Test Permission",
+        "description" : "Permiso de prueba que aplica a usuarios con rol de Administrador",
+        "type" : "resource",
+        "logic" : "POSITIVE",
+        "decisionStrategy" : "UNANIMOUS",
+        "config" : {
+          "resources" : "[\"admin-auth-test\"]",
+          "applyPolicies" : "[\"Admins Test Policy\"]"
+        }
+      }, {
+        "name" : "Test Permission",
+        "description" : "Permiso de prueba que aplica a cualquier usuario",
+        "type" : "resource",
+        "logic" : "POSITIVE",
+        "decisionStrategy" : "UNANIMOUS",
+        "config" : {
+          "defaultResourceType" : "",
+          "resources" : "[\"auth-test\"]",
+          "applyPolicies" : "[\"Default Policy\"]"
+        }
+      }, {
+        "name" : "Operator Test Permission",
+        "description" : "Permiso de prueba que aplica a usuarios con rol de Operador",
+        "type" : "resource",
+        "logic" : "POSITIVE",
+        "decisionStrategy" : "UNANIMOUS",
+        "config" : {
+          "resources" : "[\"operator-auth-test\"]",
+          "applyPolicies" : "[\"Operators or Admin Test Policy\"]"
+        }
+      } ],
+      "scopes" : [ ],
+      "decisionStrategy" : "UNANIMOUS"
+    }
   }, {
     "id" : "08200060-c6ea-4e51-9ff5-94de78c3f8ae",
     "clientId" : "security-admin-console",
@@ -1483,7 +1642,7 @@
       "subType" : "anonymous",
       "subComponents" : { },
       "config" : {
-        "allowed-protocol-mapper-types" : [ "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper", "oidc-address-mapper", "saml-user-property-mapper", "oidc-usermodel-attribute-mapper", "saml-role-list-mapper", "saml-user-attribute-mapper", "oidc-usermodel-property-mapper" ]
+        "allowed-protocol-mapper-types" : [ "oidc-full-name-mapper", "oidc-usermodel-property-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-user-attribute-mapper", "oidc-address-mapper", "saml-role-list-mapper", "oidc-usermodel-attribute-mapper", "saml-user-property-mapper" ]
       }
     }, {
       "id" : "a9b8995d-c7c7-46fa-ad0e-b52b7d8dc855",
@@ -1492,7 +1651,7 @@
       "subType" : "authenticated",
       "subComponents" : { },
       "config" : {
-        "allowed-protocol-mapper-types" : [ "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper", "oidc-usermodel-property-mapper", "saml-role-list-mapper", "saml-user-attribute-mapper", "oidc-address-mapper", "oidc-usermodel-attribute-mapper", "saml-user-property-mapper" ]
+        "allowed-protocol-mapper-types" : [ "oidc-full-name-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-usermodel-attribute-mapper", "saml-user-property-mapper", "saml-role-list-mapper", "oidc-usermodel-property-mapper", "saml-user-attribute-mapper", "oidc-address-mapper" ]
       }
     }, {
       "id" : "c0187572-93a6-4723-bde9-6fa5e2f36f78",


### PR DESCRIPTION
Este PR incluye varios cambios a al middleware de autenticación, archivos de configuración, y dependencias en el `api`. Los cambios más importantes son la actualización al middleware `requireAuth` para usar OAuth 2.0 UMA, y la modificación a la configuración del realm por defecto de Keycloak para dar soporte a servicios de autorización. Estos cambios mejoran la seguridad y flexibilidad al mecanismo de autorización dentro del RESTful API.

### Cambios a la configuración del RESTful API
* [`api/config/config.js`](diffhunk://#diff-191588e7166ad926ad59baf91e71d150dd4e1ae8087b0d45dfd11b87adda84d3R7): Se agregó la variable de entorno `OIDC_TOKEN_URI`.
* [`api/default.env`](diffhunk://#diff-4663cf622e37ca7f4311972a58590b203f13c9d11ac714f98bf0d4274cc0da0eR6): Se agregó la variable de entorno `OIDC_TOKEN_URI`.

### Cambios al middleware
* [`api/middleware/requireAuth.js`](diffhunk://#diff-c34c969614f13c3b9e9db19ab8e6554468f53f7af878bc3b0f7bcedb0e0e16efR1-R69): Se actualizó el middleware `requireAuth` para validar los tokens de acceso y permisos de los usuarios usando OAuth 2.0 UMA.

### Actualizaciones de dependencias
* `api/package.json` and `api/package-lock.json`: Se agregó la dependencia de `axios` requerido para el middleware de autenticación.

### Cambios a la configuración de Keycloak
* [`keycloak/default-realm.json`](diffhunk://#diff-57ea732c3b142e2f76ec83d5b8fbad60e9acb9de9270e7718b491c903eaa5224L120-R120): Se actualizó la configuración del realm por defecto de Keycloak para habilitar servicios de autorización, y definir políticas y permisos de prueba para distintos roles.